### PR TITLE
Add float64 and friends, including C code

### DIFF
--- a/src/coq_float64.c
+++ b/src/coq_float64.c
@@ -1,0 +1,74 @@
+/************************************************************************/
+/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*  v      *         Copyright INRIA, CNRS and contributors             */
+/* <O___,, * (see version control and CREDITS file for authors & dates) */
+/*   \VV/  **************************************************************/
+/*    //   *    This file is distributed under the terms of the         */
+/*         *     GNU Lesser General Public License Version 2.1          */
+/*         *     (see LICENSE file for the text of the license)         */
+/************************************************************************/
+
+#include <math.h>
+#include <stdint.h>
+
+#define CAML_INTERNALS
+#include <caml/alloc.h>
+
+#include "coq_values.h"
+
+union double_bits {
+  double d;
+  uint64_t u;
+};
+
+static double next_up(double x) {
+  union double_bits bits;
+  if (!(x < INFINITY)) return x; // x is +oo or NaN
+  bits.d = x;
+  int64_t i = bits.u;
+  if (i >= 0) ++bits.u; // x >= +0.0, go away from zero
+  else if (bits.u + bits.u == 0) bits.u = 1; // x is -0.0, should almost never happen
+  else --bits.u; // x < 0.0, go toward zero
+  return bits.d;
+}
+
+static double next_down(double x) {
+  union double_bits bits;
+  if (!(x > -INFINITY)) return x; // x is -oo or NaN
+  bits.d = x;
+  int64_t i = bits.u;
+  if (i == 0) bits.u = INT64_MIN + 1; // x is +0.0
+  else if (i < 0) ++bits.u; // x <= -0.0, go away from zero
+  else --bits.u; // x > 0.0, go toward zero
+  return bits.d;
+}
+
+#define DECLARE_FBINOP(name, e)                                         \
+  double coq_##name(double x, double y) {                               \
+    return e;                                                           \
+  }                                                                     \
+                                                                        \
+  value coq_##name##_byte(value x, value y) {                           \
+    return caml_copy_double(coq_##name(Double_val(x), Double_val(y)));  \
+  }
+
+#define DECLARE_FUNOP(name, e)                                          \
+  double coq_##name(double x) {                                         \
+    return e;                                                           \
+  }                                                                     \
+                                                                        \
+  value coq_##name##_byte(value x) {                                    \
+    return caml_copy_double(coq_##name(Double_val(x)));                 \
+  }
+
+DECLARE_FBINOP(fmul, x * y)
+DECLARE_FBINOP(fadd, x + y)
+DECLARE_FBINOP(fsub, x - y)
+DECLARE_FBINOP(fdiv, x / y)
+DECLARE_FUNOP(fsqrt, sqrt(x))
+DECLARE_FUNOP(next_up, next_up(x))
+DECLARE_FUNOP(next_down, next_down(x))
+
+value coq_is_double(value x) {
+  return Val_long(Is_double(x));
+}

--- a/src/coq_uint63_native.c
+++ b/src/coq_uint63_native.c
@@ -1,0 +1,190 @@
+/************************************************************************/
+/*         *   The Coq Proof Assistant / The Coq Development Team       */
+/*  v      *         Copyright INRIA, CNRS and contributors             */
+/* <O___,, * (see version control and CREDITS file for authors & dates) */
+/*   \VV/  **************************************************************/
+/*    //   *    This file is distributed under the terms of the         */
+/*         *     GNU Lesser General Public License Version 2.1          */
+/*         *     (see LICENSE file for the text of the license)         */
+/************************************************************************/
+
+#include <caml/alloc.h>
+#include <caml/mlvalues.h>
+
+#define Is_uint63(v) (Is_long(v))
+
+#define uint_of_value(val) (((uint64_t)(val)) >> 1)
+#define uint63_of_value(val) ((uint64_t)(val) >> 1)
+#define int63_of_value(val) ((int64_t)(val) >> 1)
+
+/* 2^63 * y + x as a value */
+//#define Val_intint(x,y) ((value)(((uint64_t)(x)) << 1 + ((uint64_t)(y) << 64)))
+
+#define uint63_zero() ((value) 1) /* 2*0 + 1 */
+#define uint63_one() ((value) 3) /* 2*1 + 1 */
+
+#define uint63_eq(x,y) ((x) == (y))
+#define Uint63_eq(r,x,y) ((r) = uint63_eq(x,y))
+#define Uint63_eq0(r,x) ((r) = ((x) == (uint64_t)1))
+#define Uint63_eqm1(r,x) ((r) = ((x) == (uint64_t)(int64_t)(-1)))
+#define uint63_lt(x,y) ((uint64_t) (x) < (uint64_t) (y))
+#define Uint63_lt(r,x,y) ((r) = uint63_lt(x,y))
+#define uint63_leq(x,y) ((uint64_t) (x) <= (uint64_t) (y))
+#define Uint63_leq(r,x,y) ((r) = uint63_leq(x,y))
+#define uint63_lts(x,y) ((int64_t) (x) < (int64_t) (y))
+#define Uint63_lts(r,x,y) ((r) = uint63_lts(x,y))
+#define uint63_les(x,y) ((int64_t) (x) <= (int64_t) (y))
+#define Uint63_les(r,x,y) ((r) = uint63_les(x,y))
+
+#define Uint63_neg(x) (accu = (value)(2 - (uint64_t) x))
+#define Uint63_add(x,y) (accu = (value)((uint64_t) (x) + (uint64_t) (y) - 1))
+#define Uint63_addcarry(x,y) (accu = (value)((uint64_t) (x) + (uint64_t) (y) + 1))
+#define Uint63_sub(x,y) (accu = (value)((uint64_t) (x) - (uint64_t) (y) + 1))
+#define Uint63_subcarry(x,y) (accu = (value)((uint64_t) (x) - (uint64_t) (y) - 1))
+#define Uint63_mul(x,y) (accu = Val_long(uint63_of_value(x) * uint63_of_value(y)))
+#define Uint63_div(x,y) (accu = Val_long(uint63_of_value(x) / uint63_of_value(y)))
+#define Uint63_mod(x,y) (accu = Val_long(uint63_of_value(x) % uint63_of_value(y)))
+#define Uint63_divs(x,y) (accu = Val_long(int63_of_value(x) / int63_of_value(y)))
+#define Uint63_mods(x,y) (accu = Val_long(int63_of_value(x) % int63_of_value(y)))
+
+#define Uint63_lxor(x,y) (accu = (value)(((uint64_t)(x) ^ (uint64_t)(y)) | 1))
+#define Uint63_lor(x,y) (accu = (value)((uint64_t)(x) | (uint64_t)(y)))
+#define Uint63_land(x,y) (accu = (value)((uint64_t)(x) & (uint64_t)(y)))
+
+/* TODO: is + or | better? OCAML uses + */
+/* TODO: is - or ^ better? */
+#define Uint63_lsl(x,y) do{ \
+  value uint63_lsl_y__ = (y); \
+  if (uint63_lsl_y__ < (uint64_t) 127) \
+    accu = (value)((((uint64_t)(x)-1) << uint63_of_value(uint63_lsl_y__)) | 1); \
+  else \
+    accu = uint63_zero(); \
+  }while(0)
+#define Uint63_lsr(x,y) do{ \
+  value uint63_lsl_y__ = (y); \
+  if (uint63_lsl_y__ < (uint64_t) 127) \
+    accu = (value)(((uint64_t)(x) >> uint63_of_value(uint63_lsl_y__)) | 1); \
+  else \
+    accu = uint63_zero(); \
+  }while(0)
+#define Uint63_asr(x,y) do{ \
+    value uint63_asr_y__ = (y); \
+    if (uint63_asr_y__ < (uint64_t) 127) \
+      accu = (value)(((int64_t)(x) >> uint63_of_value(uint63_asr_y__)) | 1); \
+    else \
+      accu = uint63_zero(); \
+  }while(0)
+
+/* addmuldiv(p,x,y) = x * 2^p + y / 2 ^ (63 - p) */
+/* (modulo 2^63) for p <= 63 */
+value uint63_addmuldiv(uint64_t p, uint64_t x, uint64_t y) {
+  uint64_t shiftby = uint63_of_value(p);
+  value r = (value)((uint64_t)(x^1) << shiftby);
+  r |= ((uint64_t)y >> (63-shiftby)) | 1;
+  return r;
+}
+#define Uint63_addmuldiv(p, x, y) (accu = uint63_addmuldiv(p, x, y))
+
+value uint63_head0(uint64_t x) {
+  int r = 0;
+  if (!(x & 0xFFFFFFFF00000000)) { x <<= 32; r += 32; }
+  if (!(x & 0xFFFF000000000000)) { x <<= 16; r += 16; }
+  if (!(x & 0xFF00000000000000)) { x <<= 8;  r += 8; }
+  if (!(x & 0xF000000000000000)) { x <<= 4;  r += 4; }
+  if (!(x & 0xC000000000000000)) { x <<= 2;  r += 2; }
+  if (!(x & 0x8000000000000000)) { x <<=1;   r += 1; }
+  return Val_int(r);
+}
+#define Uint63_head0(x) (accu = uint63_head0(x))
+
+value uint63_tail0(value x) {
+  int r = 0;
+  x = (uint64_t)x >> 1;
+  if (!(x & 0xFFFFFFFF)) { x >>= 32; r += 32; }
+  if (!(x & 0x0000FFFF)) { x >>= 16; r += 16; }
+  if (!(x & 0x000000FF)) { x >>= 8;  r += 8; }
+  if (!(x & 0x0000000F)) { x >>= 4;  r += 4; }
+  if (!(x & 0x00000003)) { x >>= 2;  r += 2; }
+  if (!(x & 0x00000001)) { x >>=1;   r += 1; }
+  return Val_int(r);
+}
+#define Uint63_tail0(x) (accu = uint63_tail0(x))
+
+value uint63_mulc(value x, value y, value* h) {
+  x = (uint64_t)x >> 1;
+  y = (uint64_t)y >> 1;
+  uint64_t lx = x & 0xFFFFFFFF;
+  uint64_t ly = y & 0xFFFFFFFF;
+  uint64_t hx = x >> 32;
+  uint64_t hy = y >> 32;
+  uint64_t hr = hx * hy;
+  uint64_t lr = lx * ly;
+  lx *= hy;
+  ly *= hx;
+  hr += (lx >> 32) + (ly >> 32);
+  lx <<= 32;
+  lr += lx;
+  if (lr < lx) { hr++; }
+  ly <<= 32;
+  lr += ly;
+  if (lr < ly) { hr++; }
+  hr = (hr << 1) | (lr >> 63);
+  *h = Val_int(hr);
+  return Val_int(lr);
+}
+#define Uint63_mulc(x, y, h) (accu = uint63_mulc(x, y, h))
+
+#define lt128(xh,xl,yh,yl) (uint63_lt(xh,yh) || (uint63_eq(xh,yh) && uint63_lt(xl,yl)))
+#define le128(xh,xl,yh,yl) (uint63_lt(xh,yh) || (uint63_eq(xh,yh) && uint63_leq(xl,yl)))
+
+#define maxuint63 ((uint64_t)0x7FFFFFFFFFFFFFFF)
+/* precondition: xh < y */
+/* outputs r and sets ql to q s.t. x = q * y + r, r < y */
+static value uint63_div21_aux(value xh, value xl, value y, value* ql) {
+  uint64_t nh = uint63_of_value(xh);
+  uint64_t nl = uint63_of_value(xl);
+  y = uint63_of_value(y);
+  uint64_t q = 0;
+  for (int i = 0; i < 63; ++i) {
+    // invariants: 0 <= nh < y, nl = (xl*2^i) % 2^64,
+    // (q*y + nh) * 2^(63-i) + (xl % 2^(63-i)) = (xh%y) * 2^63 + xl
+    nl <<= 1;
+    nh = (nh << 1) | (nl >> 63);
+    q <<= 1;
+    if (nh >= y) { q |= 1; nh -= y; }
+  }
+  *ql = Val_int(q);
+  return Val_int(nh);
+}
+value uint63_div21(value xh, value xl, value y, value* ql) {
+  if (uint63_leq(y, xh)) {
+    *ql = Val_int(0);
+    return Val_int(0);
+  } else {
+    return uint63_div21_aux(xh, xl, y, ql);
+  }
+}
+#define Uint63_div21(xh, xl, y, q) (accu = uint63_div21(xh, xl, y, q))
+
+#define Uint63_to_double(x) Coq_copy_double((double) uint63_of_value(x))
+
+double coq_uint63_to_float(value x) {
+  return (double) uint63_of_value(x);
+}
+
+value coq_uint63_to_float_byte(value x) {
+  return caml_copy_double(coq_uint63_to_float(x));
+}
+
+#define Uint63_of_double(f) do{ \
+  accu = Val_long((uint64_t)(f)); \
+  }while(0)
+
+#define Uint63_of_int(x) (accu = (x))
+
+#define Uint63_to_int_min(n, m) do { \
+  if (uint63_lt((n),(m))) \
+    accu = (n); \
+  else \
+    accu = (m); \
+  }while(0)

--- a/src/coq_values.h
+++ b/src/coq_values.h
@@ -1,0 +1,58 @@
+/***********************************************************************/
+/*                                                                     */
+/*                           Coq Compiler                              */
+/*                                                                     */
+/*        Benjamin Gregoire, projets Logical and Cristal               */
+/*                        INRIA Rocquencourt                           */
+/*                                                                     */
+/*                                                                     */
+/***********************************************************************/
+
+#ifndef _COQ_VALUES_
+#define _COQ_VALUES_
+
+#include <caml/alloc.h>
+#include <caml/mlvalues.h>
+
+#include <float.h>
+
+#define Default_tag 0
+
+#define ATOM_ID_TAG 0
+#define ATOM_INDUCTIVE_TAG 1
+#define ATOM_TYPE_TAG 2
+#define ATOM_PROJ_TAG 3
+#define ATOM_FIX_TAG 4
+#define ATOM_SWITCH_TAG 5
+#define ATOM_COFIX_TAG 6
+#define ATOM_COFIXEVALUATED_TAG 7
+
+#define Is_double(v) (Tag_val(v) == Double_tag)
+#define Is_tailrec_switch(v) (Field(v,1) == Val_true)
+
+/* coq values for primitive operations */
+#define coq_tag_C1 2
+#define coq_tag_C0 1
+#define coq_tag_pair 1
+#define coq_true Val_int(0)
+#define coq_false Val_int(1)
+#define coq_Eq Val_int(0)
+#define coq_Lt Val_int(1)
+#define coq_Gt Val_int(2)
+#define coq_FEq Val_int(0)
+#define coq_FLt Val_int(1)
+#define coq_FGt Val_int(2)
+#define coq_FNotComparable Val_int(3)
+#define coq_PNormal Val_int(0)
+#define coq_NNormal Val_int(1)
+#define coq_PSubn Val_int(2)
+#define coq_NSubn Val_int(3)
+#define coq_PZero Val_int(4)
+#define coq_NZero Val_int(5)
+#define coq_PInf Val_int(6)
+#define coq_NInf Val_int(7)
+#define coq_NaN Val_int(8)
+
+#define FLOAT_EXP_SHIFT (2101) /* 2*emax + prec */
+
+#endif /* _COQ_VALUES_ */

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,10 @@
  (public_name coq-uint63.uint63)
  (flags :standard -w -27-50)
  (modules_without_implementation cSig)
- (modules cMap cSig int uint63))
+ (modules cMap cSig int uint63)
+ (foreign_stubs
+  (language c)
+  (names coq_uint63_native)))
 
 (library
  (name float64)

--- a/src/dune
+++ b/src/dune
@@ -15,4 +15,7 @@
  (public_name coq-uint63.float64)
  (flags :standard -w -27-50)
  (libraries uint63)
- (modules float64 float64_common))
+ (modules float64 float64_common)
+ (foreign_stubs
+  (language c)
+  (names coq_float64)))

--- a/src/dune
+++ b/src/dune
@@ -4,4 +4,12 @@
  (public_name coq-uint63.uint63)
  (flags :standard -w -27-50)
  (modules_without_implementation cSig)
- (modules (:standard)))
+ (modules cMap cSig int uint63))
+
+(library
+ (name float64)
+ (synopsis "The Coq float64 library")
+ (public_name coq-uint63.float64)
+ (flags :standard -w -27-50)
+ (libraries uint63)
+ (modules float64 float64_common))

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,6 @@
 (library
  (name uint63)
- (synopsis "The Coq uint63 library")
+ (synopsis "Coq's uint63 OCaml library")
  (public_name coq-uint63.uint63)
  (flags :standard -w -27-50)
  (modules_without_implementation cSig)
@@ -11,11 +11,17 @@
 
 (library
  (name float64)
- (synopsis "The Coq float64 library")
+ (synopsis "Coq's float64 OCaml library")
  (public_name coq-uint63.float64)
- (flags :standard -w -27-50)
  (libraries uint63)
  (modules float64 float64_common)
  (foreign_stubs
   (language c)
   (names coq_float64)))
+
+(library
+ (name parray)
+ (synopsis "Coq's parray OCaml library")
+ (public_name coq-uint63.parray)
+ (libraries uint63)
+ (modules parray))

--- a/src/float64.ml
+++ b/src/float64.ml
@@ -1,0 +1,36 @@
+# 1 "kernel/float64_63.ml"
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+include Float64_common
+
+let mul (x : float) (y : float) : float = x *. y
+[@@ocaml.inline always]
+
+let add (x : float) (y : float) : float = x +. y
+[@@ocaml.inline always]
+
+let sub (x : float) (y : float) : float = x -. y
+[@@ocaml.inline always]
+
+let div (x : float) (y : float) : float = x /. y
+[@@ocaml.inline always]
+
+let sqrt (x : float) : float = sqrt x
+[@@ocaml.inline always]
+
+(*** Test at runtime that no harmful double rounding seems to
+   be performed with an intermediate 80 bits representation (x87). *)
+let () =
+  let b = ldexp 1. 53 in
+  let s = add 1. (ldexp 1. (-52)) in
+  if add b s <= b || add b 1. <> b || ldexp 1. (-1074) <= 0. then
+    failwith "Detected non IEEE-754 compliant architecture (or wrong \
+              rounding mode). Use of Float is thus unsafe."

--- a/src/float64.ml
+++ b/src/float64.ml
@@ -1,4 +1,3 @@
-# 1 "kernel/float64_63.ml"
 (************************************************************************)
 (*         *   The Coq Proof Assistant / The Coq Development Team       *)
 (*  v      *         Copyright INRIA, CNRS and contributors             *)

--- a/src/float64.mli
+++ b/src/float64.mli
@@ -1,0 +1,109 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** [t] is currently implemented by OCaml's [float] type.
+
+Beware: NaNs have a sign and a payload, while they should be
+indistinguishable from Coq's perspective. *)
+type t
+
+(** Test functions for special values to avoid calling [classify] *)
+val is_nan : t -> bool
+val is_infinity : t -> bool
+val is_neg_infinity : t -> bool
+
+val of_string : string -> t
+
+(** Print a float exactly as an hexadecimal value (exact decimal
+ * printing would be possible but sometimes requires more than 700
+ * digits). *)
+val to_hex_string : t -> string
+
+(** Print a float as a decimal value. The printing is not exact (the
+ * real value printed is not always the given floating-point value),
+ * however printing is precise enough that forall float [f],
+ * [of_string (to_decimal_string f) = f]. *)
+val to_string : t -> string
+
+val compile : t -> string
+
+val of_float : float -> t
+
+(** All NaNs are normalized to [Stdlib.nan].
+    @since 8.15 *)
+val to_float : t -> float
+
+(** Return [true] for "-", [false] for "+". *)
+val sign : t -> bool
+
+val opp : t -> t
+val abs : t -> t
+
+type float_comparison = FEq | FLt | FGt | FNotComparable
+
+val eq : t -> t -> bool
+
+val lt : t -> t -> bool
+
+val le : t -> t -> bool
+
+(** The IEEE 754 float comparison.
+ * NotComparable is returned if there is a NaN in the arguments *)
+val compare : t -> t -> float_comparison
+[@@ocaml.inline always]
+
+type float_class =
+  | PNormal | NNormal | PSubn | NSubn | PZero | NZero | PInf | NInf | NaN
+
+val classify : t -> float_class
+[@@ocaml.inline always]
+
+val mul : t -> t -> t
+
+val add : t -> t -> t
+
+val sub : t -> t -> t
+
+val div : t -> t -> t
+
+val sqrt : t -> t
+
+(** Link with integers *)
+val of_uint63 : Uint63.t -> t
+[@@ocaml.inline always]
+
+val normfr_mantissa : t -> Uint63.t
+[@@ocaml.inline always]
+
+(** Shifted exponent extraction *)
+val eshift : int
+
+val frshiftexp : t -> t * Uint63.t (* float remainder, shifted exponent *)
+[@@ocaml.inline always]
+
+val ldshiftexp : t -> Uint63.t -> t
+[@@ocaml.inline always]
+
+val next_up : t -> t
+
+val next_down : t -> t
+
+(** Return true if two floats are equal.
+ * All NaN values are considered equal. *)
+val equal : t -> t -> bool
+[@@ocaml.inline always]
+
+val hash : t -> int
+
+(** Total order relation over float values. Behaves like [Pervasives.compare].*)
+val total_compare : t -> t -> int
+
+val is_float64 : Obj.t -> bool
+[@@ocaml.inline always]

--- a/src/float64_common.ml
+++ b/src/float64_common.ml
@@ -1,0 +1,144 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* OCaml's float type follows the IEEE 754 Binary64 (double precision)
+   format *)
+type t = float
+
+(* The [f : float] type annotation enable the compiler to compile f <> f
+   as comparison on floats rather than the polymorphic OCaml comparison
+   which is much slower. *)
+let is_nan (f : float) = f <> f
+let is_infinity f = f = infinity
+let is_neg_infinity f = f = neg_infinity
+
+(* OCaml gives a sign to nan values which should not be displayed as
+   all NaNs are considered equal here.
+   OCaml prints infinities as "inf" (resp. "-inf")
+   but we want "infinity" (resp. "neg_infinity"). *)
+let to_string_raw fmt f =
+  if is_nan f then "nan"
+  else if is_infinity f then "infinity"
+  else if is_neg_infinity f then "neg_infinity"
+  else Printf.sprintf fmt f
+
+let to_hex_string = to_string_raw "%h"
+
+(* Printing a binary64 float in 17 decimal places and parsing it again
+   will yield the same float. *)
+let to_string = to_string_raw "%.17g"
+
+let of_string = float_of_string
+
+(* Compiles a float to OCaml code *)
+let compile f =
+  Printf.sprintf "Float64.of_float (%s)" (to_hex_string f)
+
+let of_float f = f
+
+let to_float f = if is_nan f then nan else f
+
+let sign f = copysign 1. f < 0.
+
+let opp = ( ~-. )
+let abs = abs_float
+
+type float_comparison = FEq | FLt | FGt | FNotComparable
+
+(* See above comment on [is_nan] for the [float] type annotations. *)
+let eq (x : float) (y : float) = x = y
+[@@ocaml.inline always]
+
+let lt (x : float) (y : float) = x < y
+[@@ocaml.inline always]
+
+let le (x : float) (y : float) = x <= y
+[@@ocaml.inline always]
+
+(* inspired by lib/util.ml; see also #10471 *)
+let pervasives_compare (x : float) (y : float) = compare x y
+
+let compare (x : float) (y : float) =
+  if x < y then FLt
+  else
+  (
+    if x > y then FGt
+    else
+    (
+      if x = y then FEq
+      else FNotComparable (* NaN case *)
+    )
+  )
+[@@ocaml.inline always]
+
+type float_class =
+  | PNormal | NNormal | PSubn | NSubn | PZero | NZero | PInf | NInf | NaN
+
+let classify x =
+  match classify_float x with
+  | FP_normal -> if 0. < x then PNormal else NNormal
+  | FP_subnormal -> if 0. < x then PSubn else NSubn
+  | FP_zero -> if 0. < 1. /. x then PZero else NZero
+  | FP_infinite -> if 0. < x then PInf else NInf
+  | FP_nan -> NaN
+[@@ocaml.inline always]
+
+let of_uint63 x = Uint63.to_float x
+[@@ocaml.inline always]
+
+let prec = 53
+let normfr_mantissa f =
+  let f = abs f in
+  if f >= 0.5 && f < 1. then Uint63.of_float (ldexp f prec)
+  else Uint63.zero
+[@@ocaml.inline always]
+
+let eshift = 2101 (* 2*emax + prec *)
+
+(* When calling frexp on a nan or an infinity, the returned value inside
+   the exponent is undefined.
+   Therefore we must always set it to a fixed value (here 0). *)
+let frshiftexp f =
+  match classify_float f with
+  | FP_zero | FP_infinite | FP_nan -> (f, Uint63.zero)
+  | FP_normal | FP_subnormal ->
+    let (m, e) = frexp f in
+    m, Uint63.of_int (e + eshift)
+[@@ocaml.inline always]
+
+let ldshiftexp f e = ldexp f (Uint63.to_int_min e (2 * eshift) - eshift)
+[@@ocaml.inline always]
+
+external next_up : float -> float = "coq_next_up_byte" "coq_next_up"
+[@@unboxed] [@@noalloc]
+
+external next_down : float -> float = "coq_next_down_byte" "coq_next_down"
+[@@unboxed] [@@noalloc]
+
+let equal f1 f2 =
+  if f1 = f2 then f1 <> 0. || sign f1 = sign f2 (* OCaml consider 0. = -0. *)
+  else is_nan f1 && is_nan f2
+[@@ocaml.inline always]
+
+let hash =
+  (* Hashtbl.hash already considers all NaNs as equal,
+     cf. https://github.com/ocaml/ocaml/commit/aea227fdebe0b5361fd3e1d0aaa42cf929052269
+     and http://caml.inria.fr/pub/docs/manual-ocaml/libref/Hashtbl.html *)
+  Hashtbl.hash
+
+let total_compare f1 f2 =
+  (* pervasives_compare considers all NaNs as equal, which is fine here,
+     but also considers -0. and +0. as equal *)
+  if f1 = 0. && f2 = 0. then pervasives_compare (1. /. f1) (1. /. f2)
+  else pervasives_compare f1 f2
+
+let is_float64 t =
+  Obj.tag t = Obj.double_tag
+[@@ocaml.inline always]

--- a/src/float64_common.mli
+++ b/src/float64_common.mli
@@ -1,0 +1,99 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** [t] is currently implemented by OCaml's [float] type.
+
+Beware: NaNs have a sign and a payload, while they should be
+indistinguishable from Coq's perspective. *)
+type t = float
+
+(** Test functions for special values to avoid calling [classify] *)
+val is_nan : t -> bool
+val is_infinity : t -> bool
+val is_neg_infinity : t -> bool
+
+val of_string : string -> t
+
+(** Print a float exactly as an hexadecimal value (exact decimal
+ * printing would be possible but sometimes requires more than 700
+ * digits). *)
+val to_hex_string : t -> string
+
+(** Print a float as a decimal value. The printing is not exact (the
+ * real value printed is not always the given floating-point value),
+ * however printing is precise enough that forall float [f],
+ * [of_string (to_decimal_string f) = f].  *)
+val to_string : t -> string
+
+val compile : t -> string
+
+val of_float : float -> t
+
+(** All NaNs are normalized to [Stdlib.nan].
+    @since 8.15 *)
+val to_float : t -> float
+
+(** Return [true] for "-", [false] for "+". *)
+val sign : t -> bool
+
+val opp : t -> t
+val abs : t -> t
+
+type float_comparison = FEq | FLt | FGt | FNotComparable
+
+val eq : t -> t -> bool
+
+val lt : t -> t -> bool
+
+val le : t -> t -> bool
+
+(** The IEEE 754 float comparison.
+ * NotComparable is returned if there is a NaN in the arguments *)
+val compare : t -> t -> float_comparison
+[@@ocaml.inline always]
+
+type float_class =
+  | PNormal | NNormal | PSubn | NSubn | PZero | NZero | PInf | NInf | NaN
+
+val classify : t -> float_class
+[@@ocaml.inline always]
+
+(** Link with integers *)
+val of_uint63 : Uint63.t -> t
+[@@ocaml.inline always]
+
+val normfr_mantissa : t -> Uint63.t
+[@@ocaml.inline always]
+
+(** Shifted exponent extraction *)
+val eshift : int
+
+val frshiftexp : t -> t * Uint63.t (* float remainder, shifted exponent *)
+[@@ocaml.inline always]
+
+val ldshiftexp : t -> Uint63.t -> t
+[@@ocaml.inline always]
+
+val next_up : t -> t
+
+val next_down : t -> t
+
+(** Return true if two floats are equal.
+ * All NaN values are considered equal. *)
+val equal : t -> t -> bool
+[@@ocaml.inline always]
+
+val hash : t -> int
+
+(** Total order relation over float values. Behaves like [Pervasives.compare].*)
+val total_compare : t -> t -> int
+
+val is_float64 : Obj.t -> bool
+[@@ocaml.inline always]

--- a/src/parray.ml
+++ b/src/parray.ml
@@ -1,0 +1,225 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Uniform Arrays: non-flat arrays (even floats are boxed, i.e., doesn't use
+    {!Obj.double_array_tag}) *)
+module UArray :
+sig
+  type 'a t
+  val empty : 'a t
+  val unsafe_get : 'a t -> int -> 'a
+  val unsafe_set : 'a t -> int -> 'a -> unit
+  val length : 'a t -> int
+  val make : int -> 'a -> 'a t
+  val copy : 'a t -> 'a t
+  val of_array : 'a array -> 'a t
+  val to_array : 'a t -> 'a array
+  (* 'a should not be float (no Obj.double_tag) *)
+  val unsafe_of_obj : Obj.t -> 'a t
+end =
+struct
+  type 'a t = Obj.t array
+  (** Guaranteed to be a non-flat array and no funny business with write
+      barriers because of the opacity of Obj.t. *)
+
+  let empty = [||]
+
+  let length (v : 'a t) = Array.length v
+
+  let of_array v =
+    if (Obj.tag (Obj.repr v) == Obj.double_array_tag) then begin
+      let n = Array.length v in
+      (* Ensure that we initialize it with a non-float *)
+      let ans = Array.make n (Obj.repr ()) in
+      for i = 0 to n - 1 do
+        Array.unsafe_set ans i (Obj.repr (Array.unsafe_get v i))
+      done;
+      ans
+    end else
+      (Obj.magic (Array.copy v))
+
+  let obj_is_float x = Obj.tag x == Obj.double_tag
+
+  let to_array (type a) (v : a t) : a array =
+    let () = assert (not (Array.exists obj_is_float v)) in
+    Obj.magic (Array.copy v)
+
+  let unsafe_of_obj (type a) (v : Obj.t) =
+    let () = assert (Obj.tag v == 0) in
+    (Obj.obj v : a t)
+
+  let unsafe_get = Obj.magic Array.unsafe_get
+  let unsafe_set = Obj.magic Array.unsafe_set
+
+  let make (type a) n (x : a) : a t =
+    (* Ensure that we initialize it with a non-float *)
+    let ans = Array.make n (Obj.repr ()) in
+    let () = Array.fill ans 0 n (Obj.repr x) in
+    ans
+
+  let copy = Array.copy
+
+end
+
+let max_array_length32 = 4194303
+
+let max_length = Uint63.of_int max_array_length32
+
+let length_to_int i = snd (Uint63.to_int2 i)
+
+let trunc_size n =
+  if Uint63.le Uint63.zero n && Uint63.lt n (Uint63.of_int max_array_length32) then
+    length_to_int n
+  else max_array_length32
+
+type 'a t = ('a kind) ref
+and 'a kind =
+  | Array of 'a UArray.t * 'a
+  | Updated of int * 'a * 'a t
+
+let unsafe_of_obj t def = ref (Array (UArray.unsafe_of_obj t, def))
+let of_array t def = ref (Array (UArray.of_array t, def))
+
+let rec rerootk t k =
+  match !t with
+  | Array (a, _) -> k a
+  | Updated (i, v, p) ->
+      let k' a =
+        let v' = UArray.unsafe_get a i in
+        UArray.unsafe_set a i v;
+        t := !p; (* i.e., Array (a, def) *)
+        p := Updated (i, v', t);
+        k a in
+      rerootk p k'
+
+let reroot t = rerootk t (fun a -> a)
+
+let length_int p =
+  UArray.length (reroot p)
+
+let length p = Uint63.of_int @@ length_int p
+
+let get p n =
+  let t = reroot p in
+  let l = UArray.length t in
+  if Uint63.le Uint63.zero n && Uint63.lt n (Uint63.of_int l) then
+    UArray.unsafe_get t (length_to_int n)
+  else
+    match !p with
+    | Array (_, def) -> def
+    | Updated _ -> assert false
+
+let set p n e =
+  let a = reroot p in
+  let l = Uint63.of_int (UArray.length a) in
+  if Uint63.le Uint63.zero n && Uint63.lt n l then
+    let i = length_to_int n in
+    let v' = UArray.unsafe_get a i in
+    UArray.unsafe_set a i e;
+    let t = ref !p in (* i.e., Array (a, def) *)
+    p := Updated (i, v', t);
+    t
+  else p
+
+let default p =
+  let _ = reroot p in
+  match !p with
+  | Array (_,def) -> def
+  | Updated _ -> assert false
+
+let make_int n def =
+  ref (Array (UArray.make n def, def))
+
+let make n def = make_int (trunc_size n) def
+
+let uinit n f =
+  if Int.equal n 0 then UArray.empty
+  else begin
+    let t = UArray.make n (f 0) in
+    for i = 1 to n - 1 do
+      UArray.unsafe_set t i (f i)
+    done;
+    t
+  end
+
+let init n f def =
+  let n = trunc_size n in
+  let t = uinit n f in
+  ref (Array (t, def))
+
+let to_array p =
+  let _ = reroot p in
+  match !p with
+  | Array (t,def) -> UArray.to_array t, def
+  | Updated _ -> assert false
+
+let copy p =
+  let _ = reroot p in
+  match !p with
+  | Array (t, def) -> ref (Array (UArray.copy t, def))
+  | Updated _ -> assert false
+
+(* Higher order combinators: the callback may update the underlying
+   array requiring a reroot between each call. To avoid doing n
+   reroots (-> O(n^2)), we copy if we have to reroot again. *)
+
+let is_rooted p = match !p with
+  | Array _ -> true
+  | Updated _ -> false
+
+type 'a cache = {
+  orig : 'a t;
+  mutable self : 'a UArray.t;
+  mutable rerooted_again : bool;
+}
+
+let make_cache p = {
+  orig = p;
+  self = reroot p;
+  rerooted_again = false;
+}
+
+let uget_cache cache i =
+  let () = if not cache.rerooted_again && not (is_rooted cache.orig)
+    then begin
+      cache.self <- UArray.copy (reroot cache.orig);
+      cache.rerooted_again <- true
+    end
+  in
+  UArray.unsafe_get cache.self i
+
+let map f p =
+  let t = make_cache p in
+  let len = UArray.length t.self in
+  let res = uinit len (fun i -> f (uget_cache t i)) in
+  let def = f (default p) in
+  ref (Array (res, def))
+
+let fold_left f x p =
+  let r = ref x in
+  let t = make_cache p in
+  let len = UArray.length t.self in
+  for i = 0 to len - 1 do
+    r := f !r (uget_cache t i)
+  done;
+  f !r (default p)
+
+let fold_left2 f a p1 p2 =
+  let r = ref a in
+  let t1 = make_cache p1 in
+  let len = UArray.length t1.self in
+  let t2 = make_cache p2 in
+  if UArray.length t2.self <> len then invalid_arg "Parray.fold_left2";
+  for i = 0 to len - 1 do
+    let v1 = uget_cache t1 i in
+    let v2 = uget_cache t2 i in
+    r := f !r v1 v2
+  done;
+  f !r (default p1) (default p2)

--- a/src/parray.mli
+++ b/src/parray.mli
@@ -1,0 +1,36 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+val max_length : Uint63.t
+
+type 'a t
+val length  : 'a t -> Uint63.t
+val length_int : 'a t -> int
+val get     : 'a t -> Uint63.t -> 'a
+val set     : 'a t -> Uint63.t -> 'a -> 'a t
+val default : 'a t -> 'a
+val make    : Uint63.t -> 'a -> 'a t
+val init    : Uint63.t -> (int -> 'a) -> 'a -> 'a t
+val copy    : 'a t -> 'a t
+
+val map : ('a -> 'b) -> 'a t -> 'b t
+
+val to_array : 'a t -> 'a array * 'a (* default *)
+(* 'a should not be float (no Obj.double_tag) *)
+
+val of_array : 'a array -> 'a (* default *) -> 'a t
+
+val unsafe_of_obj : Obj.t -> 'a -> 'a t
+(* [unsafe_of_obj] injects an untyped mutable array into a persistent one, but
+   does not perform a copy. This means that if the persistent array is mutated,
+   the original one will be too. The array must be a non-flat array. *)
+
+val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+val fold_left2 : ('a -> 'b -> 'c -> 'a) -> 'a -> 'b t -> 'c t -> 'a


### PR DESCRIPTION
@yforster this PR adds `float64` and the required C files to make the `prim-integers` example file `axioms.ml` from `coq-malfunction` compile (at least locally).

Do you mind testing it out? If successful, maybe we should indeed call this package/repo `coq-primitives` to indicate a more general scope.